### PR TITLE
Chinese character in the author field

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -27,6 +27,7 @@
 %====================
 % CONTACT INFORMATION
 %====================
+\CJK{UTF8}{min}
 \author{YourName} % Name Here
 \def\phone{YourPhoneNumber}
 \def\city{YourLocation}


### PR DESCRIPTION
I like your work.

When I tried to some Chinese character in author field, I got below error:

```
! Package inputenc Error: Unicode character 金 (U+91D1)
(inputenc)                not set up for use with LaTeX.
```

Solved it by adding single line
` \CJK{UTF8}{min}`

By adding this line, I can change author name like this:
`\author{joan doe (中文)}`

Thank you.